### PR TITLE
Updates for PyO3 0.21+ `Bound<'py, T>` API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /Cargo.lock
 example_project/target/
+/.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ documentation = "https://github.com/dylanbstorey/pyo3-pylogger"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pyo3 = { version = ">0.17" }
+pyo3 = { version = ">0.21", features = ["gil-refs"] }
 log = { version = "0.4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ documentation = "https://github.com/dylanbstorey/pyo3-pylogger"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pyo3 = { version = ">0.21", features = ["gil-refs"] }
+pyo3 = { version = ">0.21" }
 log = { version = "0.4" }

--- a/example_project/Cargo.lock
+++ b/example_project/Cargo.lock
@@ -29,12 +29,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,9 +59,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -95,16 +89,6 @@ name = "libc"
 version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
-
-[[package]]
-name = "lock_api"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -137,48 +121,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.1"
+name = "portable-atomic"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-sys",
-]
+checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.71"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75cb1540fadbd5b8fbccc4dddad2734eba435053f725621c070711a14bb5f4b8"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pyo3"
-version = "0.20.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e8453b658fe480c3e70c8ed4e3d3ec33eb74988bd186561b0cc66b85c3bc4b"
+checksum = "831e8e819a138c36e212f3af3fd9eeffed6bf1510a805af35b0edee5ffa59433"
 dependencies = [
  "cfg-if",
  "indoc",
  "libc",
  "memoffset",
- "parking_lot",
+ "once_cell",
+ "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
@@ -187,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.20.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96fe70b176a89cff78f2fa7b3c930081e163d5379b4dcdf993e3ae29ca662e5"
+checksum = "1e8730e591b14492a8945cdff32f089250b05f5accecf74aeddf9e8272ce1fa8"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -197,9 +165,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "214929900fd25e6604661ed9cf349727c8920d47deff196c4e28165a6ef2a96b"
+checksum = "5e97e919d2df92eb88ca80a037969f44e5e70356559654962cbb3316d00300c6"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -207,9 +175,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac53072f717aa1bfa4db832b39de8c875b7c7af4f4a6fe93cdbf9264cf8383b"
+checksum = "eb57983022ad41f9e683a599f2fd13c3664d7063a3ac5714cae4b7bee7d3f206"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -219,19 +187,20 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7774b5a8282bd4f25f803b1f0d945120be959a36c72e08e7cd031c792fdfd424"
+checksum = "ec480c0c51ddec81019531705acac51bcdbeae563557c982aa8263bb96880372"
 dependencies = [
  "heck",
  "proc-macro2",
+ "pyo3-build-config",
  "quote",
  "syn",
 ]
 
 [[package]]
 name = "pyo3-pylogger"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "log",
  "pyo3",
@@ -239,20 +208,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -273,22 +233,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "smallvec"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
-
-[[package]]
 name = "syn"
-version = "2.0.42"
+version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b7d0a2c048d661a1a59fcd7355baa232f7ed34e0ee4df2eef3c1c1c0d3852d8"
+checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -297,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.5"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
+checksum = "4873307b7c257eddcb50c9bedf158eb669578359fb28428bef438fec8e6ba7c2"
 
 [[package]]
 name = "termcolor"
@@ -352,60 +300,3 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"

--- a/example_project/Cargo.toml
+++ b/example_project/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 pyo3-pylogger = {path = ".." }
-pyo3 = {}
+pyo3 = { version = ">0.21", features = ["gil-refs"] }
 log = { version = "0.4" }
 env_logger = { version = "0.9" }

--- a/example_project/Cargo.toml
+++ b/example_project/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 pyo3-pylogger = {path = ".." }
-pyo3 = { version = ">0.21", features = ["gil-refs"] }
+pyo3 = { version = ">0.21" }
 log = { version = "0.4" }
 env_logger = { version = "0.9" }

--- a/example_project/src/main.rs
+++ b/example_project/src/main.rs
@@ -14,19 +14,21 @@ fn main() {
     pyo3::prepare_freethreaded_python();
     Python::with_gil(|py| {
         // Python code can now `import logging` as usual
-        py.run("import logging", None, None).unwrap();
-        py.run("logging.getLogger().setLevel(0)", None, None)
+        py.run_bound("import logging", None, None).unwrap();
+        py.run_bound("logging.getLogger().setLevel(0)", None, None)
             .unwrap();
         // Log messages are forwarded to `log` and dealt with by the subscriber
-        py.run("logging.debug('DEBUG')", None, None).unwrap();
-        py.run("logging.info('INFO')", None, None).unwrap();
+        py.run_bound("logging.debug('DEBUG')", None, None).unwrap();
+        py.run_bound("logging.info('INFO')", None, None).unwrap();
 
         //
-        py.run("logging.warning('WARNING')", None, None).unwrap();
-        py.run("logging.error('ERROR')", None, None).unwrap();
-        py.run("logging.critical('CRITICAL')", None, None).unwrap();
+        py.run_bound("logging.warning('WARNING')", None, None)
+            .unwrap();
+        py.run_bound("logging.error('ERROR')", None, None).unwrap();
+        py.run_bound("logging.critical('CRITICAL')", None, None)
+            .unwrap();
 
-
-        py.run("logging.getLogger('foo.bar.baz').info('INFO')", None, None).unwrap();
+        py.run_bound("logging.getLogger('foo.bar.baz').info('INFO')", None, None)
+            .unwrap();
     });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ fn host_log(record: &PyAny, rust_target: &str) -> PyResult<()> {
     } else {
         // Libraries (ex: tracing_subscriber::filter::Directive) expect rust-style targets like foo::bar,
         // and may not deal well with "." as a module separator:
-        let logger_name = logger_name.replace(".", "::");
+        let logger_name = logger_name.replace('.', "::");
         Some(format!("{rust_target}::{logger_name}"))
     };
     let target = full_target.as_deref().unwrap_or(rust_target);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ fn host_log(record: &PyAny, rust_target: &str) -> PyResult<()> {
         .to_string()
         .parse::<u32>()
         .unwrap();
-    
+
     let logger_name = record.getattr("name")?.to_string();
 
     let full_target: Option<String> = if logger_name.trim().is_empty() || logger_name == "root" {
@@ -33,8 +33,7 @@ fn host_log(record: &PyAny, rust_target: &str) -> PyResult<()> {
         let logger_name = logger_name.replace(".", "::");
         Some(format!("{rust_target}::{logger_name}"))
     };
-    let target = full_target.as_ref().map(|x| x.as_str()).unwrap_or(rust_target);
-
+    let target = full_target.as_deref().unwrap_or(rust_target);
 
     // error
     let error_metadata = if level.ge(40u8)? {


### PR DESCRIPTION
This branch transitions the project to the new `Bound<'py, T>` API in PyO3 0.21+.  See [this blog post](https://polar.sh/davidhewitt/posts/replacing-pyo3-api-pt1) and the [0.20 to 0.21 migration guide](https://pyo3.rs/v0.22.0/migration.html#from-020-to-021) for more information. Along the way I also tacked on a couple of fixes for `cargo clippy` findings, and a small `.gitignore` update.

