### PR TITLE
 lib: use pathname for record file

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,37 +36,23 @@ fn host_log(record: &PyAny, rust_target: &str) -> PyResult<()> {
     let target = full_target.as_ref().map(|x| x.as_str()).unwrap_or(rust_target);
 
 
-    // error
-    let error_metadata = if level.ge(40u8)? {
-        MetadataBuilder::new()
-            .target(target)
-            .level(Level::Error)
-            .build()
+    let mut metadata_builder = MetadataBuilder::new();
+    metadata_builder.target(target);
+    if level.ge(40u8)? {
+        metadata_builder.level(Level::Error)
     } else if level.ge(30u8)? {
-        MetadataBuilder::new()
-            .target(target)
-            .level(Level::Warn)
-            .build()
+        metadata_builder.level(Level::Warn)
     } else if level.ge(20u8)? {
-        MetadataBuilder::new()
-            .target(target)
-            .level(Level::Info)
-            .build()
+        metadata_builder.level(Level::Info)
     } else if level.ge(10u8)? {
-        MetadataBuilder::new()
-            .target(target)
-            .level(Level::Debug)
-            .build()
+        metadata_builder.level(Level::Debug)
     } else {
-        MetadataBuilder::new()
-            .target(target)
-            .level(Level::Trace)
-            .build()
+        metadata_builder.level(Level::Trace)
     };
 
     logger().log(
         &Record::builder()
-            .metadata(error_metadata)
+            .metadata(metadata_builder.build())
             .args(format_args!("{}", &message))
             .line(Some(lineno))
             .file(Some("app.rs"))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ fn host_log(record: &PyAny, rust_target: &str) -> PyResult<()> {
             .metadata(metadata_builder.build())
             .args(format_args!("{}", &message))
             .line(Some(lineno))
-            .file(Some("app.rs"))
+            .file(Some(&pathname))
             .module_path(Some(&pathname))
             .build(),
     );


### PR DESCRIPTION
Previously the `RecordBuilder` used in `host_log()` to construct a `Log` item hardcoded the record's `file()` as `Some("app.rs")`. 
https://github.com/dylanbstorey/pyo3-pylogger/blob/d89e0d6820ebc4f067647e3b74af59dbc4941dd5/src/lib.rs#L72

This branch updates the logic to use `&pathname` ("Full pathname of the source file where the logging call was issued (if available).") instead. 

This value is already being provided to `module_path()`, but arguably that usage should be changed to `record.getattr("module")` (described in  the [python docs](https://docs.python.org/3/library/logging.html#logrecord-attributes) as "Module (name portion of filename).") instead of `record.getattr("pathname")`. I've left that as-is for now pending discussion since it doesn't affect the default formatting of `tracing` events, and that's where my focus is today.

Before this change when using `tracing-log` to adapt the `Log` record to the `tracing` ecosystem w/ default formatting an event like the following was produced:

```
2024-07-23T15:31:24.376313Z DEBUG init: app.rs:10: User Python Loaded!
```

Afterwards, it produces an event like:

```
2024-07-23T15:50:38.273451Z DEBUG init: /home/daniel/.config/pup/user_test.py:10: User Python Loaded!
```

Along the way I tidied up the builder construction a little bit :-)

Relates to https://github.com/dylanbstorey/pyo3-pylogger/issues/5