### PR TITLE
Follow-ups from #6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-pylogger"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 authors = ["Dylan Bobby Storey <dylan.storey@gmail.com>"]
 description = "Enables `log` for pyo3 based Rust applications using the `logging` modules."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ documentation = "https://github.com/dylanbstorey/pyo3-pylogger"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pyo3 = { version = ">0.21" }
+pyo3 = { version = ">=0.21" }
 log = { version = "0.4" }


### PR DESCRIPTION
Couple quick follow-ups from https://github.com/dylanbstorey/pyo3-pylogger/pull/6:

* fix pyo3 version constraint - This should have been `>=`, not `>`, because 0.21 _and_ 0.22 are compatible :)
* version 0.2.2 -> 0.3.0 - to match [the GitHub release](https://github.com/dylanbstorey/pyo3-pylogger/releases/tag/0.3.0)